### PR TITLE
Now users can set custom close button on modal.

### DIFF
--- a/react-exercises/modal-react/src/components/modal/modal-close-button.component.jsx
+++ b/react-exercises/modal-react/src/components/modal/modal-close-button.component.jsx
@@ -1,0 +1,34 @@
+import React, { useContext } from 'react';
+import ModalContext from './modal-context.component';
+
+const CloseButton = (props) => {
+  let { closeModalCallback, closeButton, backdrop, onEscapeClose } = useContext(
+    ModalContext
+  );
+
+  if (props.closeButton !== 'undefined' && typeof props.closeButton === 'boolean') {
+    closeButton = props.closeButton;
+  }
+  if (!backdrop && !onEscapeClose) {
+    closeButton = true;
+  }
+  const handleCloseButtonClick = () => {
+    closeModalCallback(false);
+  };
+
+  console.log(props.children);
+  return (
+    closeButton && (
+      <button
+        className="modal-close"
+        aria-label="modal-close-button"
+        data-modal-close-button="true"
+        onClick={() => handleCloseButtonClick()}
+      >
+        {props.children ? props.children : 'X'}
+      </button>
+    )
+  );
+};
+
+export default CloseButton;

--- a/react-exercises/modal-react/src/components/modal/modal-header.component.jsx
+++ b/react-exercises/modal-react/src/components/modal/modal-header.component.jsx
@@ -1,35 +1,7 @@
-import React, { useContext } from 'react';
-import ModalContext from './modal-context.component';
+import React from 'react';
 
 const Header = (props) => {
-  let { closeModalCallback, closeButton, backdrop, onEscapeClose } = useContext(
-    ModalContext
-  );
-
-  if (props.closeButton !== 'undefined' && typeof props.closeButton === 'boolean') {
-    closeButton = props.closeButton;
-  }
-  if (!backdrop && !onEscapeClose) {
-    closeButton = true;
-  }
-  const handleCloseButtonClick = () => {
-    closeModalCallback(false);
-  };
-  return (
-    <div className="modal-header">
-      {props.children}
-      {closeButton && (
-        <button
-          className="modal-closeBtn"
-          aria-label="modal-closeBtn"
-          data-modal-close-button="true"
-          onClick={() => handleCloseButtonClick()}
-        >
-          X
-        </button>
-      )}
-    </div>
-  );
+  return <div className="modal-header">{props.children}</div>;
 };
 
 export default Header;

--- a/react-exercises/modal-react/src/components/modal/modal.component.jsx
+++ b/react-exercises/modal-react/src/components/modal/modal.component.jsx
@@ -6,6 +6,7 @@ import Dialog from './modal-dialog.component';
 import Header from './modal-header.component';
 import Title from './modal-title.component';
 import Footer from './modal-footer.component';
+import CloseButton from './modal-close-button.component';
 import {
   TAB_KEY_CODE,
   ESCAPE_KEY_CODE,
@@ -81,5 +82,6 @@ Modal.Header = Header;
 Modal.Title = Title;
 Modal.Body = Body;
 Modal.Footer = Footer;
+Modal.CloseButton = CloseButton;
 
 export default Modal;

--- a/react-exercises/modal-react/src/components/modal/modal.styles.css
+++ b/react-exercises/modal-react/src/components/modal/modal.styles.css
@@ -25,6 +25,7 @@
   box-shadow: 5px 7px 20px 10px rgba(0, 0, 0, 0.2);
   overflow: auto;
   margin: auto;
+  position: relative;
 }
 
 .modal-header {
@@ -59,7 +60,7 @@
   border-bottom-left-radius: calc(0.3rem - 1px);
 }
 
-.modal-closeBtn {
+.modal-close {
   background-color: #b0b0b0;
   display: inline-block;
   -webkit-user-select: none;
@@ -72,4 +73,7 @@
   color: white;
   border-radius: 5px;
   cursor: pointer;
+  position: absolute;
+  right: 0px;
+  z-index: 999;
 }

--- a/react-exercises/modal-react/src/components/signin-modal/signin-modal.component.jsx
+++ b/react-exercises/modal-react/src/components/signin-modal/signin-modal.component.jsx
@@ -10,7 +10,8 @@ const SignInModal = (props) => {
   };
   return (
     <Modal closeModalCallback={props.closeModalCallback}>
-      <Modal.Header closeButton>
+      <Modal.CloseButton></Modal.CloseButton>
+      <Modal.Header>
         <Modal.Title>SIGN IN</Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/react-exercises/modal-react/src/components/signup-modal/signup-modal.component.jsx
+++ b/react-exercises/modal-react/src/components/signup-modal/signup-modal.component.jsx
@@ -10,7 +10,8 @@ const SignUpModal = (props) => {
   };
   return (
     <Modal closeModalCallback={props.closeModalCallback}>
-      <Modal.Header closeButton>
+      <Modal.CloseButton></Modal.CloseButton>
+      <Modal.Header>
         <Modal.Title>SIGN UP</Modal.Title>
       </Modal.Header>
       <Modal.Body>


### PR DESCRIPTION
Users can pass image, emoji, SVG, or text inside Modal.CloseButton component. Then the passed element will be shown as a close button. If nothing is passed then the default close button will be shown.